### PR TITLE
Derive root key pair from mnemonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This package is a plugin for DApps on Flow blockchain that already use [FCL](https://github.com/onflow/fcl-js). It enables users to log in in through popular social login providers such as Google, Facebook, Discord and others. With a [couple of lines of code](https://github.com/nufi-official/walletless-flow/pull/12), allow your users to onboard more easily through social login of their choice and keep your FCL integration untouched. A "Kitty Items" demo app using this lib is deployed at https://walletless.nu.fi/ and [here](https://web3auth.io/) you can find more about Web3Auth, the service powering this package.
 
-![login](https://github.com/nufi-official/fcl-web3auth-plugin/assets/22474126/4623f55b-2f94-4e70-ae11-6701bfd15b52)
+![Walletless FCL 1mb](https://github.com/nufi-official/fcl-web3auth-plugin/assets/22474126/a105b482-f92d-4e46-bb0d-8898ff350ae3)
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ Experimental feature, not production ready, waiting for the official standard fo
 
 The keys are derived according to [FLIP-200](https://github.com/onflow/flow/pull/200)
 
-- get `seed` from web3auth
+- get `entropy` from web3auth
+- create `mnemonic` from `entropy` using bip39
+- get `seed` from mnemonic
 - derive bip32 keypair using `m/44'/539'/0'/0/0` path
 - use `secp256k1` derivation curve
 - use `SHA2` hashing algorithm

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ setCallbacks({
 
 ### `experimentalLinkAccount(args: LinkAccountArgs): Promise<string>`
 
-Experimental feature, not production ready, waiting for the official standard for hybrid custody to be finalized
+Experimental feature, not production ready, waiting for the official standard for [hybrid custody](https://developers.flow.com/concepts/hybrid-custody) to be finalized
 
 - submits two transaction, first a child account (Web3Auth account) publishes its auth account capability to the parent address, then the parent (a regular wallet like NuFi, Lilico) submits a transaction claiming the capability
 
@@ -138,7 +138,7 @@ Experimental feature, not production ready, waiting for the official standard fo
 The keys are derived according to [FLIP-200](https://github.com/onflow/flow/pull/200)
 
 - get `entropy` from web3auth
-- create `mnemonic` from `entropy` using bip39
+- create `mnemonic` from `entropy` using bip39 (this ensures portability of the account to [NuFi](https://nu.fi) wallet even without [account-linking](#experimentallinkaccountargs-linkaccountargs-promisestring)
 - get `seed` from mnemonic
 - derive bip32 keypair using `m/44'/539'/0'/0/0` path
 - use `secp256k1` derivation curve

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nufi/fcl-web3auth-plugin",
-  "version": "1.0.0-alpha.7",
+  "version": "2.0.0-alpha.0",
   "description": "Integrate Web3Auth (social login) into your Flow DApp with minimal code",
   "homepage": "https://nu.fi",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@web3auth/core": "^4.6.0",
     "@web3auth/openlogin-adapter": "^5.1.1",
     "bip32": "^4.0.0",
+    "bip39": "^3.1.0",
     "elliptic": "^6.5.4",
     "sha2": "^1.0.2",
     "tiny-secp256k1": "1.1.6"

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -7,6 +7,7 @@ import * as fcl from '@onflow/fcl'
 import {Web3AuthConnection} from '../web3auth/connection'
 import {hashMsgHex, secp256k1, seedToKeyPair} from './signUtils'
 import {Web3AuthLoginProvider, Web3authUserMetadata} from '../web3auth/types'
+import {entropyToMnemonic, mnemonicToSeed} from 'bip39'
 
 export class Wallet {
   public accountInfo: AccountInfo | null = null
@@ -92,7 +93,8 @@ export class Wallet {
     privateKey: Buffer
     userMetadata: Web3authUserMetadata
   }): Promise<AccountInfo> => {
-    const rootKeyPair = seedToKeyPair(userInfo.privateKey.toString('hex'))
+    const mnemonic = entropyToMnemonic(userInfo.privateKey.toString('hex'))
+    const rootKeyPair = seedToKeyPair(await mnemonicToSeed(mnemonic))
     const address = await this.ensureAccountIsCreatedOnChain(rootKeyPair.pubKey)
     const {keys, ...rest} = await fcl.account(address)
     const pubKeyInfo = keys.find((k) => k.publicKey === rootKeyPair.pubKey)

--- a/src/wallet/signUtils.ts
+++ b/src/wallet/signUtils.ts
@@ -10,9 +10,9 @@ const sansUncompressedPrefix = (uncompressedPubKey: string): PubKey =>
 
 export const secp256k1 = new EC('secp256k1')
 
-export const seedToKeyPair = (rootSeed: string): RootKeyPair => {
+export const seedToKeyPair = (rootSeed: Buffer): RootKeyPair => {
   const path = "m/44'/539'/0'/0/0"
-  const rootNode = bip32.fromSeed(Buffer.from(rootSeed, 'hex'))
+  const rootNode = bip32.fromSeed(rootSeed)
   const child = rootNode.derivePath(path)
   assert(!!child.privateKey)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,9 +3026,9 @@ socket.io-client@^4.6.1:
     socket.io-parser "~4.2.1"
 
 socket.io-parser@~4.2.1:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.2.tgz#1dd384019e25b7a3d374877f492ab34f2ad0d206"
-  integrity sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.3.tgz#926bcc6658e2ae0883dc9dee69acbdc76e4e3667"
+  integrity sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,6 +1352,13 @@ bip32@^4.0.0:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
+bip39@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.1.0.tgz#c55a418deaf48826a6ceb34ac55b3ee1577e18a3"
+  integrity sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==
+  dependencies:
+    "@noble/hashes" "^1.2.0"
+
 bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"


### PR DESCRIPTION
Motivation
 - allow us to possibly export mnemonic from which the keys are derived, so user can recover his web3auth wallet elsewhere and is not stuck with the dapp

Changes:
 - instead of getting the root key pair from the entropy we first create a mnemonic from that entropy, and get the root key pair from it
